### PR TITLE
fix: remove double default exports

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,40 +1,20 @@
-import 'react-native-gesture-handler';
-import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Text, View,Button } from "react-native";
-import { NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import "react-native-gesture-handler";
+import { NavigationContainer } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
+import {
+  FrederickatheGreat_400Regular,
+  useFonts
+} from "@expo-google-fonts/fredericka-the-great";
+import { NanumBrushScript_400Regular } from "@expo-google-fonts/nanum-brush-script";
+import { Play_400Regular } from "@expo-google-fonts/play";
+import { ShareTechMono_400Regular } from "@expo-google-fonts/share-tech-mono";
+import { SpecialElite_400Regular } from "@expo-google-fonts/special-elite";
 
+import SettingsScreen from "./src/screens/SettingsScreen";
+import ProfileScreen from "./src/screens/ProfileScreen";
+import HomeScreen from "./src/screens/HomeScreen";
+import NotificationsScreen from "./src/screens/NotificationsScreen";
 
-import HomeScreen from './src/screens/HomeScreen';
-import NotificationsScreen from './src/screens/NotificationsScreen';
-import ProfileScreen from './src/screens/ProfileScreen';
-import SettingsScreen from './src/screens/SettingsScreen';
-import { useFonts, FrederickatheGreat_400Regular, } from '@expo-google-fonts/fredericka-the-great';
-import { NanumBrushScript_400Regular } from '@expo-google-fonts/nanum-brush-script';
-import { Play_400Regular } from '@expo-google-fonts/play';
-import { ShareTechMono_400Regular } from '@expo-google-fonts/share-tech-mono';
-import { SpecialElite_400Regular } from '@expo-google-fonts/special-elite';
-
-
-export default function App() {
-  let [fontsLoaded] = useFonts({
-    FrederickatheGreat_400Regular, NanumBrushScript_400Regular, Play_400Regular, ShareTechMono_400Regular, SpecialElite_400Regular
-  });
-
-  if (!fontsLoaded) {
-    return null;
-  }
-
-  return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text style={{ fontFamily: 'FrederickatheGreat_400Regular', fontSize: 40 }}>FrederickatheGreat</Text>
-      <Text style={{ fontFamily: 'NanumBrushScript_400Regular', fontSize: 40 }}>NanumBrushScrip</Text>
-      <Text style={{ fontFamily: 'Play', fontSize: 40 }}>play</Text>
-      <Text style={{ fontFamily: 'ShareTechMono_400Regular', fontSize: 40 }}>ShareTechMono</Text>
-      <Text style={{ fontFamily: 'SpecialElite_400Regular', fontSize: 40 }}>SpecialElite</Text>
-    </View>
-  );
-}
 const Stack = createStackNavigator();
 
 function MyStack() {
@@ -44,21 +24,23 @@ function MyStack() {
       <Stack.Screen name="Notifications" component={NotificationsScreen} />
       <Stack.Screen name="Profile" component={ProfileScreen} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
-      </Stack.Navigator>
+    </Stack.Navigator>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});
-
-
 export default function App() {
+  let [fontsLoaded] = useFonts({
+    FrederickatheGreat_400Regular,
+    NanumBrushScript_400Regular,
+    Play_400Regular,
+    ShareTechMono_400Regular,
+    SpecialElite_400Regular
+  });
+
+  if (!fontsLoaded) {
+    return null;
+  }
+
   return (
     <NavigationContainer>
       <MyStack />

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,17 +1,32 @@
-import { Button, View } from "react-native";
-import { useFonts } from 'expo-font';
-
+import { Button, Text, View } from "react-native";
 
 const HomeScreen = ({ navigation }) => {
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+      <Text
+        style={{ fontFamily: "FrederickatheGreat_400Regular", fontSize: 40 }}
+      >
+        FrederickatheGreat
+      </Text>
+      <Text style={{ fontFamily: "NanumBrushScript_400Regular", fontSize: 40 }}>
+        NanumBrushScript
+      </Text>
+      <Text style={{ fontFamily: "Play", fontSize: 40 }}>play</Text>
+      <Text style={{ fontFamily: "ShareTechMono_400Regular", fontSize: 40 }}>
+        ShareTechMono
+      </Text>
+      <Text style={{ fontFamily: "SpecialElite_400Regular", fontSize: 40 }}>
+        SpecialElite
+      </Text>
+
+      <View style={{ margin: 16 }} />
+
       <Button
         title="Go to Profile"
-        onPress={() => navigation.navigate('Profile')}
+        onPress={() => navigation.navigate("Profile")}
       />
     </View>
   );
-}
+};
 
 export default HomeScreen;
-


### PR DESCRIPTION
Here is a detailed explanation of the changes, with screenshots:

1. There are two default exports in App.js. You are only allowed to have one default export in a JS file. See lines 19 and 61
2. Fix: Move the fonts into the HomeScreen leaving just one export default(_line 61_).
3. See the screenshots to see the changes.
4. Notice the red line in line 61 in the original App.js file. That is ESLint notifying me of the error. One of the many benefits of ESLint 👍🏾 

<table>
  <tr>
    <td>
    <p>App.js BEFORE</p>
    <img src="https://github.com/Dare54/clock/assets/66207244/5ed28466-6c88-4d52-9985-804bb69a3635" alt="App.js BEFORE" width="383"/></td>
    <td>
    <p>App.js AFTER</p>
    <img src="https://github.com/Dare54/clock/assets/66207244/8b4ff9ca-3866-467b-8b90-e8b4c6a05409" alt="App.js AFTER" width="364"/></td>
  </tr>
</table>

------------------------------------------------------------------------------------------------------------------


<table>
  <tr>
    <td>
    <p>HomeScreen.js BEFORE</p>
    <img src="https://github.com/Dare54/clock/assets/66207244/d2649607-52c0-45ac-9929-fe8546d01b32" alt="HomeScreen.js BEFORE" width="364"/></td>
    <td>
     <p>HomeScreen.js AFTER</p>
    <img src="https://github.com/Dare54/clock/assets/66207244/49cc42d1-6e10-496f-873d-503772d2b29c" alt="HomeScreen.js AFTER" width="383"/></td>
  </tr>
</table>

